### PR TITLE
Applying wildcard serialize to getters

### DIFF
--- a/can-map-define.js
+++ b/can-map-define.js
@@ -354,7 +354,8 @@ proto.serialize = function(property) {
 		// if it's not already defined
 		if (!(attr in serialized)) {
 			// check there is a serializer so we aren't doing extra work on serializer:false
-			serializer = this.define && this.define[attr] && this.define[attr].serialize;
+			// also check for a wildcard serializer
+			serializer = this.define && (this.define[attr] && this.define[attr].serialize || this.define['*'] && this.define['*'].serialize);
 			if (serializer) {
 				val = serializeProp(this, attr, this.attr(attr));
 				if (val !== undefined) {

--- a/can-map-define_test.js
+++ b/can-map-define_test.js
@@ -1267,4 +1267,31 @@ test("nullish values are not converted for Type", function(assert) {
 	assert.equal(vm.attr("map"), null, "notype is null");
 });
 
+test("Wildcard serialize doesn't apply to getter properties (#4)", function() {
+	var VM = CanMap.extend({
+		define: {
+			explicitlySerialized: {
+				get: function () {
+					return true;
+				},
+				serialize: true
+			},
+			implicitlySerialized: {
+				get: function () {
+					return true;
+				}
+			},
+			'*': {
+				serialize: true
+			}
+		}
+	});
 
+	var vm = new VM();
+	vm.bind('change', function() {});
+
+	deepEqual(vm.serialize(), {
+		explicitlySerialized: true,
+		implicitlySerialized: true
+	});
+});


### PR DESCRIPTION
Fix for https://github.com/canjs/can-map-define/issues/4.