### PR TITLE
Consistency of behaviors for passing null and undefined to type and Type

### DIFF
--- a/can-map-define.js
+++ b/can-map-define.js
@@ -217,6 +217,9 @@ define.types = {
 		return +(val);
 	},
 	'boolean': function(val) {
+		if(val == null) {
+			return val;
+		}
 		if (val === 'false' || val === '0' || !val) {
 			return false;
 		}
@@ -271,8 +274,8 @@ proto.__type = function(value, prop) {
 		if (type) {
 			newValue = type.call(this, newValue, prop);
 		}
-		// If there's a Type create a new instance of it
-		if (Type && !(newValue instanceof Type)) {
+		// If there's a Type and newValue is non-null create a new instance of it
+		if (Type && newValue != null && !(newValue instanceof Type)) {
 			newValue = new Type(newValue);
 		}
 		// If the newValue is a Map, we need to hook it up

--- a/can-map-define_test.js
+++ b/can-map-define_test.js
@@ -1101,7 +1101,7 @@ test("type converters handle null and undefined in expected ways (1693)", functi
 
 	equal(t.attr("number"), undefined, "converted to number");
 
-	equal(t.attr("boolean"), false, "converted to boolean");
+	equal(t.attr("boolean"), undefined, "converted to boolean");
 
 	equal(t.attr("htmlbool"), false, "converted to htmlbool");
 
@@ -1122,7 +1122,7 @@ test("type converters handle null and undefined in expected ways (1693)", functi
 
 	equal(t.attr("number"), null, "converted to number");
 
-	equal(t.attr("boolean"), false, "converted to boolean");
+	equal(t.attr("boolean"), null, "converted to boolean");
 
 	equal(t.attr("htmlbool"), false, "converted to htmlbool");
 
@@ -1232,3 +1232,39 @@ test("double get in a compute (#2230)", function() {
 	c.bind("change", function() {});
 
 });
+
+test("nullish values are not converted for Type", function(assert) {
+
+	var VM = CanMap.extend({
+		define: {
+			map: {
+				Type: CanMap
+			},
+			notype: {},
+		}
+	});
+
+	var vm = new VM({
+		num: 1,
+		bool: true,
+		htmlbool: "foo",
+		str: "foo",
+		date: Date.now(),
+		map: {},
+		notype: {}
+	});
+
+	// Sanity check
+	assert.ok(vm.attr("map") instanceof CanMap, "map is a Map");
+	assert.ok(vm.attr("notype") instanceof CanMap, "notype is a Map");
+
+	vm.attr({
+		map: null,
+		notype: null
+	});
+
+	assert.equal(vm.attr("map"), null, "map is null");
+	assert.equal(vm.attr("map"), null, "notype is null");
+});
+
+


### PR DESCRIPTION
[This will require doc updates once #9 is merged]

Major changes in this PR:

* if `{type: "boolean"}`, `null` and `undefined` remain as is instead of being converted to `false`.  This makes the "boolean" type align with how numbers, strings, dates are treated.  However, `{type: "htmlbool"}` has not changed and will convert nullish values to `false`.

* Any `Type` conversion will treat `null` and `undefined` as is instead of creating a new instance.