### PR TITLE
Allow setting properties to undefined

### DIFF
--- a/can-map-define.js
+++ b/can-map-define.js
@@ -170,7 +170,7 @@ proto.__set = function(prop, value, current, success, error) {
 			return;
 		}
 		// if it took a setter and returned nothing, don't set the value
-		else if (setValue === undefined && !setterCalled && setter.length >= 1) {
+		else if (setValue === undefined && !setterCalled && setter.length > 1) {
 			//!steal-remove-start
 			asyncTimer = setTimeout(function() {
 				dev.warn('can/map/define: Setter "' + prop + '" did not return a value or call the setter callback.');

--- a/can-map-define_test.js
+++ b/can-map-define_test.js
@@ -1306,3 +1306,23 @@ test("compute props can be set to null or undefined (#2372)", function(assert) {
 	var vmUndef = new VM({foo: undefined});
 	assert.equal(vmUndef.foo, undefined, "foo is null, no error thrown");
 });
+
+test("can set properties to undefined", function(){
+	var MyMap = CanMap.extend({
+		define: {
+			foo: {
+				set: function(newVal) {
+					return newVal;
+				}
+			}
+		}
+	});
+
+	var map = new MyMap();
+
+	map.attr('foo', 'bar');
+	equal(map.attr('foo'), 'bar', 'foo should be bar');
+
+	map.attr('foo', undefined);
+	equal(typeof map.attr('foo'), 'undefined', 'foo should be undefined'); 
+});

--- a/package.json
+++ b/package.json
@@ -28,31 +28,11 @@
     "develop": "done-serve --static --develop --port 8080"
   },
   "main": "dist/cjs/can-map-define",
-  "browser": {
-    "transform": [
-      "cssify"
-    ]
-  },
-  "browserify": {
-    "transform": [
-      "cssify"
-    ]
-  },
   "keywords": [
     "canjs"
   ],
   "system": {
     "main": "can-map-define",
-    "configDependencies": [
-      "live-reload"
-    ],
-    "npmIgnore": [
-      "documentjs",
-      "testee",
-      "generator-donejs",
-      "donejs-cli",
-      "steal-tools"
-    ],
     "npmAlgorithm": "flat"
   },
   "dependencies": {
@@ -70,8 +50,6 @@
     "can-model": "^2.3.11",
     "can-route": "^3.0.0-pre.8",
     "can-stache": "^3.0.0-pre.11",
-    "cssify": "^0.6.0",
-    "documentjs": "^0.4.2",
     "done-serve": "^0.2.0",
     "donejs-cli": "^0.8.0",
     "generator-donejs": "^0.9.0",


### PR DESCRIPTION
This is the 3.0 fix for https://github.com/canjs/canjs/issues/2523

The setter logic interprets returning undefined as if the value will be
set with the asynchronous setVal. It does this by looking at the number
of params in the setter function; if 2 then it is an async setter.
However the check was >= 1, when it should have been just > 1.

This should be easily backportable to 2.3.x.