### PR TITLE
Replace deprecated can-util/js/is-array with Array.isArray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ node_js: node
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
+addons:
+  firefox: "51.0"

--- a/can-map-define_test.js
+++ b/can-map-define_test.js
@@ -1,6 +1,5 @@
 /* jshint asi: false */
 var QUnit = require('steal-qunit');
-var isArray = require('can-util/js/is-array/is-array');
 var string = require('can-util/js/string/string');
 var CanMap = require('can-map');
 var List = require('can-list');
@@ -319,7 +318,7 @@ test("basics value", function() {
 	var t1 = new Typer2(),
 		t2 = new Typer2();
 	ok(t1.attr("prop") !== t2.attr("prop"), "different array instances");
-	ok(isArray(t1.attr("prop")), "its an array");
+	ok(Array.isArray(t1.attr("prop")), "its an array");
 
 
 });
@@ -338,7 +337,7 @@ test("basics Value", function() {
 	var t1 = new Typer(),
 		t2 = new Typer();
 	ok(t1.attr("prop") !== t2.attr("prop"), "different array instances");
-	ok(isArray(t1.attr("prop")), "its an array");
+	ok(Array.isArray(t1.attr("prop")), "its an array");
 
 
 });
@@ -1306,7 +1305,7 @@ test("compute props can be set to null or undefined (#2372)", function(assert) {
 test("can inherit computes from another map (#2)", 4, function(){
  		var string1 = 'a string';
  		var string2 = 'another string';
- 
+
  		var MapA = CanMap.extend({
  			define: {
  				propA: {
@@ -1340,7 +1339,7 @@ test("can inherit computes from another map (#2)", 4, function(){
  		});
 
 		var map = new MapB();
-		
+
 		equal(map.attr('propC'), string2, 'props only in the child have the correct values');
  		equal(map.attr('propB'), string2, 'props in both have the child values');
  		equal(map.attr('propA'), string1, 'props only in the parent have the correct values');
@@ -1410,15 +1409,15 @@ test("can inherit object values from another map (#2)", function(){
 				get: function() {
 					return object2;
 				}
-			}	
+			}
 		}
 	});
-	
+
 	var map = new MapB();
 
 	equal(map.attr('propC'), 	object2, 'props only in the child have the correct values');
 	equal(map.attr('propB'), 	object2, 'props in both have the child values');
-	equal(map.attr('propA'), 	object1, 'props only in the parent have the correct values');	
+	equal(map.attr('propA'), 	object1, 'props only in the parent have the correct values');
 });
 
 
@@ -1439,7 +1438,7 @@ test("can set properties to undefined", function(){
 	equal(map.attr('foo'), 'bar', 'foo should be bar');
 
 	map.attr('foo', undefined);
-	equal(typeof map.attr('foo'), 'undefined', 'foo should be undefined'); 
+	equal(typeof map.attr('foo'), 'undefined', 'foo should be undefined');
 });
 
 test("subclass defines do not affect superclass ones", function(assert) {

--- a/docs/attrDefinition.md
+++ b/docs/attrDefinition.md
@@ -4,7 +4,7 @@
 Defines the type, initial value, and get, set, and remove behavior for an attribute of a [can-map Map].
 
 @option {can-map-define.value|*} value Specifies the initial value of the attribute or
-a function that returns the initial value. For example, a default value of `0` can be 
+a function that returns the initial value. For example, a default value of `0` can be
 specified like:
 
     define: {
@@ -14,7 +14,7 @@ specified like:
     }
 
 `Object` types should not be specified directly on `value` because that same object will
-be shared on every instance of the Map.  Instead, a [can-map-define.value value function] that 
+be shared on every instance of the Map.  Instead, a [can-map-define.value value function] that
 returns a fresh copy can be provided:
 
     define: {
@@ -34,8 +34,8 @@ set as the initial value of the attribute. For example, if the default value sho
       }
     }
 
-@option {can-map-define._type|String} type Specifies the type of the 
-attribute.  The type can be specified as either a [can-map-define._type type function] 
+@option {can-map-define._type|String} type Specifies the type of the
+attribute.  The type can be specified as either a [can-map-define._type type function]
 that returns the type coerced value or one of the following strings:
 
  - `"string"` - Converts the value to a string.
@@ -52,15 +52,15 @@ The following example converts the `count` property to a number and the `items` 
          type: function(newValue){
            if(typeof newValue === "string") {
              return newValue.split(",")
-           } else if( can.isArray(newValue) ) {
+           } else if( Array.isArray(newValue) ) {
              return newValue;
            }
          }
        }
      }
 
-@option {can-map-define.TypeConstructor} Type A constructor function that takes 
-the value passed to [can-map.prototype.attr attr] as the first argument and called with 
+@option {can-map-define.TypeConstructor} Type A constructor function that takes
+the value passed to [can-map.prototype.attr attr] as the first argument and called with
 new. For example, if you want whatever
 gets passed to go through `new Array(newValue)` you can do that like:
 
@@ -79,13 +79,13 @@ defines a `page` setter that updates the map's offset:
     define: {
       page: {
         set: function(newVal){
-          this.attr('offset', (parseInt(newVal) - 1) * 
+          this.attr('offset', (parseInt(newVal) - 1) *
                                this.attr('limit'));
         }
       }
     }
 
-@option {can-map-define.get} get A function that specifies how the value is retrieved.  The get function is 
+@option {can-map-define.get} get A function that specifies how the value is retrieved.  The get function is
 converted to an [can-compute.async async compute].  It should derive its value from other values
 on the map. The following
 defines a `page` getter that reads from a map's offset and limit:
@@ -93,12 +93,12 @@ defines a `page` getter that reads from a map's offset and limit:
     define: {
       page: {
         get: function (newVal) {
-		  return Math.floor(this.attr('offset') / 
+		  return Math.floor(this.attr('offset') /
 		                    this.attr('limit')) + 1;
 		}
       }
     }
-    
+
 A `get` definition makes the property __computed__ which means it will not be serialized by default.
 
 @option {can-map-define.remove} remove A function that specifies what should happen when an attribute is removed
@@ -112,8 +112,8 @@ with [can-map.prototype.removeAttr removeAttr]. The following removes a `modelId
       }
     }
 
-@option {can-map-define.serialize|Boolean} serialize Specifies the behavior of the 
-property when [can-map.prototype.serialize serialize] is called. 
+@option {can-map-define.serialize|Boolean} serialize Specifies the behavior of the
+property when [can-map.prototype.serialize serialize] is called.
 
 By default, serialize does not include computed values. Properties with a `get` definition
 are computed and therefore are not added to the result.  Non-computed properties values are
@@ -126,7 +126,7 @@ serialized if possible and added to the result.
         }
       }
     });
-    
+
     p = new Paginate({offset: 40});
     p.serialize() //-> {offset: 40}
 
@@ -134,7 +134,7 @@ If `true` is specified, computed properties will be serialized and added to the 
 
     Paginate = Map.extend({
       define: {
-        pageNum: { 
+        pageNum: {
           get: function(){ return this.offset() / 20 },
           serialize: true
         }
@@ -143,8 +143,8 @@ If `true` is specified, computed properties will be serialized and added to the 
 
     p = new Paginate({offset: 40});
     p.serialize() //-> {offset: 40, pageNum: 2}
-    
-    
+
+
 If `false` is specified, non-computed properties will not be added to the result.
 
     Paginate = Map.extend({
@@ -173,4 +173,3 @@ of the function is added to the result.
 
     p = new Paginate({offset: 40});
     p.serialize() //-> {offset: 3}
-    

--- a/docs/type.md
+++ b/docs/type.md
@@ -35,7 +35,7 @@ The following example converts the `count` property to a number and the `items` 
          type: function(newValue){
            if(typeof newValue === "string") {
              return newValue.split(",")
-           } else if( can.isArray(newValue) ) {
+           } else if( Array.isArray(newValue) ) {
              return newValue;
            }
          }


### PR DESCRIPTION
See https://github.com/canjs/can-util/issues/225. We are now using `Array.isArray` directly.