### PR TITLE
79 implement get own enumerable keys

### DIFF
--- a/can-map-define.js
+++ b/can-map-define.js
@@ -409,7 +409,7 @@ canReflect.assignSymbols(proto, {
 			newKey = dataKeys[i];
 			// add keys that are in _data, but are not in `define`
 			// keys in `define` are in `definedKeys` based on their `serialize` prop
-			if (definedKeys.indexOf(newKey) < 0 && !this.define[newKey]) {
+			if (definedKeys.indexOf(newKey) < 0 && this.define && !this.define[newKey]) {
 				definedKeys.push(dataKeys[i]);
 			}
 		}

--- a/can-map-define.js
+++ b/can-map-define.js
@@ -383,6 +383,28 @@ canReflect.assignSymbols(proto, {
 		var dataExists = this._data && key in this._data;
 		var propExists = key in this;
 		return defined || dataExists || propExists;
+	},
+	"can.getOwnEnumerableKeys": function() {
+		// what keys/props do i care about?
+		// handle inheritance?
+		// if no serialize attribute, what's the default?
+		// key vs prop vs attribute (random q)
+
+		var define = this.define
+		var defineKeys = Object.keys(this.define);
+		var dataKeys = Object.keys(this._data);
+		var parentKeys = Object.keys(this);
+		var enumerableKeys = []
+
+		if (defineKeys.length) {
+			defineKeys.forEach(function(key) {
+				if (define[key]["serialize"] === undefined || define[key]["serialize"] === true) {
+					enumerableKeys.push(key)
+				}
+			});
+		}
+
+		return enumerableKeys;
 	}
 });
 

--- a/can-map-define_test.js
+++ b/can-map-define_test.js
@@ -5,7 +5,6 @@ var CanMap = require('can-map');
 var List = require('can-list');
 var compute = require('can-compute');
 var canReflect = require('can-reflect');
-var canSymbol = require("can-symbol");
 
 require('./can-map-define');
 
@@ -1309,49 +1308,49 @@ QUnit.test("compute props can be set to null or undefined (#2372)", function(ass
 });
 
 QUnit.test("can inherit computes from another map (#2)", 4, function(){
- 		var string1 = 'a string';
- 		var string2 = 'another string';
+	var string1 = 'a string';
+	var string2 = 'another string';
 
- 		var MapA = CanMap.extend({
- 			define: {
- 				propA: {
- 					get: function() {
- 						return string1;
- 					}
- 				},
- 				propB: {
- 					get: function() {
- 						return string1;
- 					},
- 					set: function(newVal) {
- 						equal(newVal, string1, 'set was called');
- 					}
- 				}
- 			}
- 		});
- 		var MapB = MapA.extend({
- 			define: {
- 				propC: {
- 					get: function() {
- 						return string2;
- 					}
- 				},
- 				propB: {
- 					get: function() {
- 						return string2;
- 					}
- 				}
- 			}
- 		});
+	var MapA = CanMap.extend({
+		define: {
+			propA: {
+				get: function() {
+					return string1;
+				}
+			},
+			propB: {
+				get: function() {
+					return string1;
+				},
+				set: function(newVal) {
+					equal(newVal, string1, 'set was called');
+				}
+			}
+		}
+	});
+	var MapB = MapA.extend({
+		define: {
+			propC: {
+				get: function() {
+					return string2;
+				}
+			},
+			propB: {
+				get: function() {
+					return string2;
+				}
+			}
+		}
+	});
 
-		var map = new MapB();
+	var map = new MapB();
 
-		equal(map.attr('propC'), string2, 'props only in the child have the correct values');
- 		equal(map.attr('propB'), string2, 'props in both have the child values');
- 		equal(map.attr('propA'), string1, 'props only in the parent have the correct values');
-		map.attr('propB', string1);
+	equal(map.attr('propC'), string2, 'props only in the child have the correct values');
+	equal(map.attr('propB'), string2, 'props in both have the child values');
+	equal(map.attr('propA'), string1, 'props only in the parent have the correct values');
+	map.attr('propB', string1);
 
- 	});
+});
 
 QUnit.test("can inherit primitive values from another map (#2)", function(){
 	var string1 = 'a';
@@ -1622,11 +1621,10 @@ QUnit.test("can.getOwnEnumerableKeys", function() {
 	});
 
 	var vm = new VM();
-	var getOwnEnumerableKeysSymbol = canSymbol.for("can.getOwnEnumerableKeys");
-	// getOwnEnumerableKeys for inherited defined props
-	deepEqual( vm[getOwnEnumerableKeysSymbol](), [ "enumerableProp", "enumByDefault", "parentEnum", "parentEnumByDefault" ], "vm.getOwnEnumerableKeys()");
+	// getOwnEnumerableKeys for defined props, including copied from Parent
+	deepEqual( canReflect.getOwnEnumerableKeys(vm), [ "enumerableProp", "enumByDefault", "parentEnum", "parentEnumByDefault" ], "vm.getOwnEnumerableKeys()");
 
 	vm.attr('lateProp', true);
-	deepEqual( vm[getOwnEnumerableKeysSymbol](), [ "enumerableProp", "enumByDefault", "parentEnum", "parentEnumByDefault", "lateProp" ], "vm.getOwnEnumerableKeys() with late prop");
+	deepEqual( canReflect.getOwnEnumerableKeys(vm), [ "enumerableProp", "enumByDefault", "parentEnum", "parentEnumByDefault", "lateProp" ], "vm.getOwnEnumerableKeys() with late prop");
 
 });

--- a/can-map-define_test.js
+++ b/can-map-define_test.js
@@ -188,7 +188,7 @@ QUnit.test("basic type", function() {
 
 
 	var t = new Typer();
-	deepEqual(CanMap.keys(t), [], "no keys");
+	deepEqual(CanMap.keys(t), ["arrayWithAddedItem", "listWithAddedItem"], "defined keys");
 
 	var array = [];
 	t.attr("arrayWithAddedItem", array);
@@ -1062,19 +1062,24 @@ QUnit.test("type converters handle null and undefined in expected ways (1693)", 
 	var Typer = CanMap.extend({
 		define: {
 			date: {
-				type: 'date'
+				type: 'date',
+				value: 'Mon Jul 30 2018 11:57:14 GMT-0500 (Central Daylight Time)'
 			},
 			string: {
-				type: 'string'
+				type: 'string',
+				value: 'mudd'
 			},
 			number: {
-				type: 'number'
+				type: 'number',
+				value: 42
 			},
 			'boolean': {
-				type: 'boolean'
+				type: 'boolean',
+				value: false
 			},
 			htmlbool: {
-				type: 'htmlbool'
+				type: 'htmlbool',
+				value: true
 			},
 			leaveAlone: {
 				type: '*'
@@ -1581,7 +1586,13 @@ QUnit.test("can.getOwnEnumerableKeys", function() {
 			},
 
 			parentEnumByDefault: {
-				value: 'parent_maybe'
+				value: 'maybe'
+			},
+
+			parentEnumGetter: {
+				get: function () {
+					return 'parent_get';
+				}
 			}
 		}
 	});
@@ -1600,13 +1611,22 @@ QUnit.test("can.getOwnEnumerableKeys", function() {
 
 			enumByDefault: {
 				value: 'maybe'
+			},
+
+			enumGetter: {
+				get: function () {
+					return 'got';
+				}
 			}
 		}
 	});
 
 	var vm = new VM();
-	var getOwnEnumerableKeysSymbol = canSymbol.for("can.getOwnEnumerableKeys")
-	equal(vm.attr('notEnumerable'), 'no', 'value matches');
+	var getOwnEnumerableKeysSymbol = canSymbol.for("can.getOwnEnumerableKeys");
 	// getOwnEnumerableKeys for inherited defined props
 	deepEqual( vm[getOwnEnumerableKeysSymbol](), [ "enumerableProp", "enumByDefault", "parentEnum", "parentEnumByDefault" ], "vm.getOwnEnumerableKeys()");
+
+	vm.attr('lateProp', true);
+	deepEqual( vm[getOwnEnumerableKeysSymbol](), [ "enumerableProp", "enumByDefault", "parentEnum", "parentEnumByDefault", "lateProp" ], "vm.getOwnEnumerableKeys() with late prop");
+
 });

--- a/can-map-define_test.js
+++ b/can-map-define_test.js
@@ -5,6 +5,7 @@ var CanMap = require('can-map');
 var List = require('can-list');
 var compute = require('can-compute');
 var canReflect = require('can-reflect');
+var canSymbol = require("can-symbol");
 
 require('./can-map-define');
 
@@ -1564,4 +1565,48 @@ QUnit.test("can.hasKey", function() {
 
 	vm.attr('lateProp', 'something');
 	equal(canReflect.hasKey(vm, "lateProp"), true, "vm.hasKey('lateProp') true");
+});
+
+QUnit.test("can.getOwnEnumerableKeys", function() {
+	var ParentMap = CanMap.extend({
+		define: {
+			parentNoEnum: {
+				serialize: false,
+				value: 'parent_no'
+			},
+
+			parentEnum: {
+				serialize: true,
+				value: 'parent_yes'
+			},
+
+			parentEnumByDefault: {
+				value: 'parent_maybe'
+			}
+		}
+	});
+
+		var VM = ParentMap.extend({
+		define: {
+			notEnumerable: {
+				serialize: false,
+				value: 'no'
+			},
+
+			enumerableProp: {
+				serialize: true,
+				value: 'yes'
+			},
+
+			enumByDefault: {
+				value: 'maybe'
+			}
+		}
+	});
+
+	var vm = new VM();
+	var getOwnEnumerableKeysSymbol = canSymbol.for("can.getOwnEnumerableKeys")
+	equal(vm.attr('notEnumerable'), 'no', 'value matches');
+	// getOwnEnumerableKeys for inherited defined props
+	deepEqual( vm[getOwnEnumerableKeysSymbol](), [ "enumerableProp", "enumByDefault", "parentEnum", "parentEnumByDefault" ], "vm.getOwnEnumerableKeys()");
 });

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "can-list": "^4.0.0",
     "can-log": "^1.0.0",
     "can-map": "^4.0.1",
+    "can-observation-recorder": "^1.2.0",
     "can-queues": "^1.0.1",
     "can-reflect": "^1.15.2",
     "can-symbol": "^1.6.1"

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "can-map": "^4.0.1",
     "can-observation-recorder": "^1.2.0",
     "can-queues": "^1.0.1",
-    "can-reflect": "^1.15.2",
-    "can-symbol": "^1.6.1"
+    "can-reflect": "^1.15.2"
   },
   "devDependencies": {
     "bit-docs": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -37,12 +37,13 @@
   "dependencies": {
     "can-assign": "^1.1.1",
     "can-compute": "^4.0.3",
-    "can-log": "^1.0.0",
     "can-event-queue": "^1.0.1",
     "can-list": "^4.0.0",
+    "can-log": "^1.0.0",
     "can-map": "^4.0.1",
     "can-queues": "^1.0.1",
-    "can-reflect": "^1.15.2"
+    "can-reflect": "^1.15.2",
+    "can-symbol": "^1.6.1"
   },
   "devDependencies": {
     "bit-docs": "0.0.7",


### PR DESCRIPTION
Not having `getOwnEnumberableKeys` on `can-map-define` was causing issues when `can-route` changes would update a top level `appState` CanMap that was bound to `route.data`. It would clear all properties on `appState` that were not being updated by the route change, even though they were set to `serialize:false` in the `define` object. Example:
```
cons appState = {
  define: { 
    page: { value: 'home' },
    laserBeams: { value: true, serialize: false }
    chickenTacos: {value: 'good', serialize: false }
  }
}
```
route change sets and update `page` to 'away' on `route.data` would set the appState to:
```
cons appState = {
  define: { 
   page: {  }  --> updated value would be 'away'
  }
}
```