### PR TITLE
fixing getOwnEnumerableKeys when there is no define object

### DIFF
--- a/can-map-define.js
+++ b/can-map-define.js
@@ -396,6 +396,7 @@ canReflect.assignSymbols(proto, {
 		var propExists = key in this;
 		return defined || dataExists || propExists;
 	},
+
 	"can.getOwnEnumerableKeys": function() {
 		if (!this.__inSetup) {
 			ObservationRecorder.add(this, '__keys');
@@ -409,7 +410,7 @@ canReflect.assignSymbols(proto, {
 			newKey = dataKeys[i];
 			// add keys that are in _data, but are not in `define`
 			// keys in `define` are in `definedKeys` based on their `serialize` prop
-			if (definedKeys.indexOf(newKey) < 0 && this.define && !this.define[newKey]) {
+			if (definedKeys.indexOf(newKey) < 0 && (!this.define || !this.define[newKey])) {
 				definedKeys.push(dataKeys[i]);
 			}
 		}

--- a/can-map-define_test.js
+++ b/can-map-define_test.js
@@ -1628,3 +1628,23 @@ QUnit.test("can.getOwnEnumerableKeys", function() {
 	deepEqual( canReflect.getOwnEnumerableKeys(vm), [ "enumerableProp", "enumByDefault", "parentEnum", "parentEnumByDefault", "lateProp" ], "vm.getOwnEnumerableKeys() with late prop");
 
 });
+
+QUnit.test("can.getOwnEnumerableKeys works without define (#81)", function() {
+	var VM = CanMap.extend({});
+
+	var vm = new VM({ foo: "bar" });
+	deepEqual( canReflect.getOwnEnumerableKeys(vm), [ "foo" ], "without define");
+
+	vm.attr("abc", "xyz");
+	deepEqual( canReflect.getOwnEnumerableKeys(vm), [ "foo", "abc" ], "without define, with late prop");
+
+	VM = CanMap.extend({
+		define: {}
+	});
+
+	vm = new VM({ foo: "bar" });
+	deepEqual( canReflect.getOwnEnumerableKeys(vm), [ "foo" ], "with empty define");
+
+	vm.attr("abc", "xyz");
+	deepEqual( canReflect.getOwnEnumerableKeys(vm), [ "foo", "abc" ], "with empty define, with late prop");
+});


### PR DESCRIPTION
closes https://github.com/canjs/can-map-define/issues/81.