### PR TITLE
adding can-reflect-tests and fixing issue with non-enumerable properties

### DIFF
--- a/can-map-define.js
+++ b/can-map-define.js
@@ -405,6 +405,13 @@ canReflect.assignSymbols(proto, {
 		var definedKeys = keysForDefinition(this.define);
 		var dataKeys = keysForDefinition(this._data);
 
+		var enumerable = this.constructor.enumerable;
+		if (enumerable) {
+			dataKeys = dataKeys.filter(function(key) {
+				return enumerable[key] !== false;
+			});
+		}
+
 		var i, newKey;
 		for(i=0; i<dataKeys.length; i++) {
 			newKey = dataKeys[i];

--- a/can-map-define_test.js
+++ b/can-map-define_test.js
@@ -1648,3 +1648,7 @@ QUnit.test("can.getOwnEnumerableKeys works without define (#81)", function() {
 	vm.attr("abc", "xyz");
 	deepEqual( canReflect.getOwnEnumerableKeys(vm), [ "foo", "abc" ], "with empty define, with late prop");
 });
+
+require("can-reflect-tests/observables/map-like/type/type")("CanMap / can-map-define", function(){
+	return CanMap.extend({});
+});

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "bit-docs": "0.0.7",
     "can-component": "^4.0.4",
     "can-key": "<2.0.0",
+    "can-reflect-tests": "^0.2.1",
     "can-route": "^4.1.1",
     "can-stache": "^4.1.3",
     "detect-cyclic-packages": "^1.1.0",


### PR DESCRIPTION
closes https://github.com/canjs/can-map-define/issues/83.