### PR TITLE
96 add resolver

### DIFF
--- a/can-map-define.js
+++ b/can-map-define.js
@@ -10,6 +10,8 @@ var compute = require('can-compute');
 var canReflect = require('can-reflect');
 var ObservationRecorder = require('can-observation-recorder');
 var canSymbol = require('can-symbol');
+var Resolver = require("can-simple-observable/resolver/resolver");
+
 require('can-list');
 
 var define = {}; // jshint ignore:line
@@ -371,6 +373,9 @@ proto._setupComputedProperties = function() {
 			get = def.get;
 		if (get) {
 			mapHelpers.addComputedAttr(this, attr, compute.async(undefined, get, this));
+		}
+		if (def.resolver) {
+			mapHelpers.addComputedAttr(this, attr, new Resolver(def.resolver, this, def.value ) );
 		}
 	}
 };

--- a/can-map-define_test.js
+++ b/can-map-define_test.js
@@ -1313,7 +1313,7 @@ QUnit.test("compute props can be set to null or undefined (#2372)", function(ass
 
 QUnit.test("can inherit computes from another map (#2)", function(assert) {
 	assert.expect(4);
-	
+
 	var string1 = 'a string';
 	var string2 = 'another string';
 
@@ -1793,7 +1793,7 @@ QUnit.test("can.getOwnEnumerableKeys with default behavior, nested maps and late
 	);
 });
 
-QUnit.test("resolver behavior: with counter (#96)", function(){
+QUnit.test("resolver behavior: with counter (#96)", function(assert){
 	var Person = CanMap.extend('Person', {
 		define: {
 			name: {
@@ -1809,18 +1809,18 @@ QUnit.test("resolver behavior: with counter (#96)", function(){
 	});
 
 	var me = new Person();
-	QUnit.equal(me.attr("nameChangedCount"), 0, "unbound value");
+	assert.equal(me.attr("nameChangedCount"), 0, "unbound value");
 
 	me.attr("name", "first");
 
-	QUnit.equal(me.attr("nameChangedCount"), 0, "unbound value");
+	assert.equal(me.attr("nameChangedCount"), 0, "unbound value");
 
 	me.on("nameChangedCount", function(ev, newVal, oldVal){
-			QUnit.equal(newVal, 1, "updated count");
-			QUnit.equal(oldVal, 0, "updated count from old value");
+			assert.equal(newVal, 1, "updated count");
+			assert.equal(oldVal, 0, "updated count from old value");
 	});
 
 	me.attr("name", "second");
 
-	QUnit.equal(me.attr("nameChangedCount"), 1, "bound value");
+	assert.equal(me.attr("nameChangedCount"), 1, "bound value");
 });

--- a/can-map-define_test.js
+++ b/can-map-define_test.js
@@ -1,5 +1,4 @@
 /* jshint asi: false */
-/*jshint esversion: 6 */
 var QUnit = require('steal-qunit');
 var sub = require('can-key/sub/sub');
 var CanMap = require('can-map');
@@ -1794,16 +1793,16 @@ QUnit.test("can.getOwnEnumerableKeys with default behavior, nested maps and late
 	);
 });
 
-QUnit.test("resolver behavior: with counter", function(){
+QUnit.test("resolver behavior: with counter (#96)", function(){
 	var Person = CanMap.extend('Person', {
 		define: {
 			name: {
 				type: "string"
 			},
 			nameChangedCount: {
-				resolver: function ({ listenTo, resolve }) {
-					var count = resolve(0);
-					listenTo("name", function() {  resolve(++count); });
+				resolver: function (prop) {
+					var count = prop.resolve(0);
+					prop.listenTo("name", function() {  prop.resolve(++count); });
 				}
 			}
 		}

--- a/can-map-define_test.js
+++ b/can-map-define_test.js
@@ -1,4 +1,5 @@
 /* jshint asi: false */
+/*jshint esversion: 6 */
 var QUnit = require('steal-qunit');
 var sub = require('can-key/sub/sub');
 var CanMap = require('can-map');
@@ -1800,9 +1801,9 @@ QUnit.test("resolver behavior: with counter", function(){
 				type: "string"
 			},
 			nameChangedCount: {
-				resolver({ listenTo, resolve }) {
+				resolver: function ({ listenTo, resolve }) {
 					var count = resolve(0);
-					listenTo("name", ()=>{  resolve(++count) })
+					listenTo("name", function() {  resolve(++count); });
 				}
 			}
 		}

--- a/can-map-define_test.js
+++ b/can-map-define_test.js
@@ -1694,7 +1694,7 @@ QUnit.test("can.getOwnEnumerableKeys with default behavior", function(assert) {
 	var vm = new VM();
 
 	assert.deepEqual(
-		canReflect.getOwnEnumerableKeys(vm), 
+		canReflect.getOwnEnumerableKeys(vm),
 		["enumerableProp"],
 		"vm.getOwnEnumerableKeys()"
 	);
@@ -1791,4 +1791,36 @@ QUnit.test("can.getOwnEnumerableKeys with default behavior, nested maps and late
 		["enumerableProp", "parentEnum"],
 		"late added properties should inherit default behavior"
 	);
+});
+
+QUnit.test("resolver behavior: with counter", function(){
+	var Person = CanMap.extend('Person', {
+		define: {
+			name: {
+				type: "string"
+			},
+			nameChangedCount: {
+				resolver({ listenTo, resolve }) {
+					var count = resolve(0);
+					listenTo("name", ()=>{  resolve(++count) })
+				}
+			}
+		}
+	});
+
+	var me = new Person();
+	QUnit.equal(me.attr("nameChangedCount"), 0, "unbound value");
+
+	me.attr("name", "first");
+
+	QUnit.equal(me.attr("nameChangedCount"), 0, "unbound value");
+
+	me.on("nameChangedCount", function(ev, newVal, oldVal){
+			QUnit.equal(newVal, 1, "updated count");
+			QUnit.equal(oldVal, 0, "updated count from old value");
+	});
+
+	me.attr("name", "second");
+
+	QUnit.equal(me.attr("nameChangedCount"), 1, "bound value");
 });

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "can-observation-recorder": "^1.2.0",
     "can-queues": "^1.0.1",
     "can-reflect": "^1.15.2",
-    "can-symbol": "^1.6.4"
+    "can-symbol": "^1.6.4",
+    "can-simple-observable": "^2.4.1"
   },
   "devDependencies": {
     "bit-docs": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-map-define",
-  "version": "4.3.8",
+  "version": "4.3.9",
   "description": "Define rich attribute behavior",
   "homepage": "https://canjs.com",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "bit-docs": "0.0.7",
     "can-component": "^4.0.4",
     "can-key": "<2.0.0",
-    "can-reflect-tests": "^0.3.1",
+    "can-reflect-tests": "^1.0.0",
     "can-route": "^4.1.1",
     "can-stache": "^4.1.3",
     "detect-cyclic-packages": "^1.1.0",


### PR DESCRIPTION
This adds the `value` behavior from `DefineMap` to `can-map-define`. Since `can-map-define` already has a behavior named `value` (to set a starting value to a property), this new behavior has been named `resolver` instead.

Closes #96 