### PR TITLE
Legacy attr compat

### DIFF
--- a/can-map-define_test.js
+++ b/can-map-define_test.js
@@ -510,7 +510,7 @@ QUnit.test("serialize basics", function(assert) {
 
 });
 
-QUnit.test("In legacy mode, .attr() keeps attributes set to serialize:false", function(assert){
+QUnit.test("(can-23) In legacy mode, .attr() keeps attributes set to serialize:false", function(assert){
 	const Person = CanMap.extend({
 		define: {
 			age: { serialize: false }

--- a/can-map-define_test.js
+++ b/can-map-define_test.js
@@ -510,6 +510,25 @@ QUnit.test("serialize basics", function(assert) {
 
 });
 
+QUnit.test("In legacy mode, .attr() keeps attributes set to serialize:false", function(assert){
+	const Person = CanMap.extend({
+		define: {
+			age: { serialize: false }
+		}
+	});
+
+	// Enable legacy behavior on Person. This is used by can-23.
+	Object.defineProperty(Person.prototype, "_legacyAttrBehavior",{
+		value: true,
+		enumerable: false
+	});
+
+	const morgan = new Person({ age: 90 });
+
+	assert.equal(morgan.attr().age, 90, ".attr() keeps attributes set to serialize:false")
+	assert.equal(morgan.serialize().age, undefined, ".serialize() removes attributes set to serialize:false")
+});
+
 QUnit.test("serialize context", function(assert) {
 	var context, serializeContext;
 	var MyMap = CanMap.extend({


### PR DESCRIPTION
Test legacy .attr keeps attrs with serialize:false

This is for can-23 and affects attributes with serialize: false.
- .serialize() will return an object with the property removed
- .attr() will return an object with the property intact.

Requires this PR to can-map: https://github.com/canjs/can-map/pull/153